### PR TITLE
Fix Flickering Numbers

### DIFF
--- a/ui/assets/js/main.js
+++ b/ui/assets/js/main.js
@@ -304,8 +304,8 @@ function formatNumber(num) {
   }).format(num);
 }
 
-htmx.onLoad((el) => {
-  htmx.findAll(el, "[format-minutes]").forEach((el) => {
+function formatAllElements(rootElement) {
+  htmx.findAll(rootElement, "[format-minutes]").forEach((el) => {
     const num = Number(el.textContent);
     if (Number.isFinite(num)) {
       const formatted = formatTime(num);
@@ -313,7 +313,7 @@ htmx.onLoad((el) => {
     }
   });
 
-  htmx.findAll(el, "[format-timestamp]").forEach((el) => {
+  htmx.findAll(rootElement, "[format-timestamp]").forEach((el) => {
     const secs = Number(el.textContent);
     if (Number.isFinite(secs)) {
       const formatted = formatTimestamp(secs);
@@ -321,13 +321,31 @@ htmx.onLoad((el) => {
     }
   });
 
-  htmx.findAll(el, "[format-number]").forEach((el) => {
+  htmx.findAll(rootElement, "[format-number]").forEach((el) => {
     const num = Number(el.textContent);
     if (Number.isFinite(num)) {
       const formatted = formatNumber(num);
       el.textContent = formatted;
     }
   });
+}
+
+// Format on initial page load
+document.addEventListener('DOMContentLoaded', function() {
+  formatAllElements(document.body)
+});
+
+// Format before we swap new element in
+document.addEventListener('htmx:beforeSwap', function(event) {
+  let content = event.detail.xhr.responseText;
+            
+  // Create a temporary container to manipulate the content
+  let tempDiv = document.createElement('div');
+  tempDiv.innerHTML = content;
+
+  formatAllElements(tempDiv)
+  
+  event.detail.serverResponse = tempDiv.innerHTML;
 });
 
 /* Autoasign an id */


### PR DESCRIPTION
Closes #28

This fixes the flickering on an htmx swap or loading the page (usually). Instead of changing the numbers server-side, it formats the numbers client-side before painting the page.

If I refresh rapidly on Chrome it seems that you can still see the non-formatted numbers, but on normal page navigation it seems to be fixed.

Also thank you for your quick comments! It never crossed my mind to think about locales when formatting numbers, and I really appreciate the guidance.