### PR TITLE
Expand search bar capabilities

### DIFF
--- a/cooklang-fs/src/lib.rs
+++ b/cooklang-fs/src/lib.rs
@@ -644,6 +644,30 @@ impl RecipeContent {
         return ingredients;
     }
 
+    /// Parses the names of cookware required by the recipe.
+    pub fn cookware(&self, parser: &cooklang::CooklangParser) -> Vec<String> {
+        Self::get_cookware_from(self.parse(parser))
+    }
+
+    /// Same as [`Self::cookware`] but with extra options
+    pub fn cookware_with_options(
+        &self,
+        parser: &cooklang::CooklangParser,
+        options: cooklang::analysis::ParseOptions,
+    ) -> Vec<String> {
+        Self::get_cookware_from(self.parse_with_options(parser, options))
+    }
+
+    fn get_cookware_from(recipe: cooklang::RecipeResult) -> Vec<String> {
+        let mut cookware = Vec::new();
+        if let Some(r) = recipe.valid_output() {
+            for tool in &r.cookware {
+                cookware.push(tool.name.to_owned());
+            }
+        }
+        return cookware;
+    }
+
     pub fn text(&self) -> &str {
         &self.content
     }

--- a/cooklang-fs/src/lib.rs
+++ b/cooklang-fs/src/lib.rs
@@ -620,54 +620,6 @@ impl RecipeContent {
         parser.parse_with_options(&self.content, options)
     }
 
-    /// Parses the names of ingredients of the recipe.
-    pub fn ingredients(&self, parser: &cooklang::CooklangParser) -> Vec<String> {
-        Self::get_ingredients_from(self.parse(parser))
-    }
-
-    /// Same as [`Self::ingredients`] but with extra options
-    pub fn ingredients_with_options(
-        &self,
-        parser: &cooklang::CooklangParser,
-        options: cooklang::analysis::ParseOptions,
-    ) -> Vec<String> {
-        Self::get_ingredients_from(self.parse_with_options(parser, options))
-    }
-
-    fn get_ingredients_from(recipe: cooklang::RecipeResult) -> Vec<String> {
-        let mut ingredients = Vec::new();
-        if let Some(r) = recipe.valid_output() {
-            for ingredient in &r.ingredients {
-                ingredients.push(ingredient.name.to_owned());
-            }
-        }
-        return ingredients;
-    }
-
-    /// Parses the names of cookware required by the recipe.
-    pub fn cookware(&self, parser: &cooklang::CooklangParser) -> Vec<String> {
-        Self::get_cookware_from(self.parse(parser))
-    }
-
-    /// Same as [`Self::cookware`] but with extra options
-    pub fn cookware_with_options(
-        &self,
-        parser: &cooklang::CooklangParser,
-        options: cooklang::analysis::ParseOptions,
-    ) -> Vec<String> {
-        Self::get_cookware_from(self.parse_with_options(parser, options))
-    }
-
-    fn get_cookware_from(recipe: cooklang::RecipeResult) -> Vec<String> {
-        let mut cookware = Vec::new();
-        if let Some(r) = recipe.valid_output() {
-            for tool in &r.cookware {
-                cookware.push(tool.name.to_owned());
-            }
-        }
-        return cookware;
-    }
-
     pub fn text(&self) -> &str {
         &self.content
     }

--- a/cooklang-fs/src/lib.rs
+++ b/cooklang-fs/src/lib.rs
@@ -620,6 +620,30 @@ impl RecipeContent {
         parser.parse_with_options(&self.content, options)
     }
 
+    /// Parses the names of ingredients of the recipe.
+    pub fn ingredients(&self, parser: &cooklang::CooklangParser) -> Vec<String> {
+        Self::get_ingredients_from(self.parse(parser))
+    }
+
+    /// Same as [`Self::ingredients`] but with extra options
+    pub fn ingredients_with_options(
+        &self,
+        parser: &cooklang::CooklangParser,
+        options: cooklang::analysis::ParseOptions,
+    ) -> Vec<String> {
+        Self::get_ingredients_from(self.parse_with_options(parser, options))
+    }
+
+    fn get_ingredients_from(recipe: cooklang::RecipeResult) -> Vec<String> {
+        let mut ingredients = Vec::new();
+        if let Some(r) = recipe.valid_output() {
+            for ingredient in &r.ingredients {
+                ingredients.push(ingredient.name.to_owned());
+            }
+        }
+        return ingredients;
+    }
+
     pub fn text(&self) -> &str {
         &self.content
     }

--- a/src/cmd/serve/async_index.rs
+++ b/src/cmd/serve/async_index.rs
@@ -20,6 +20,7 @@ pub struct AsyncFsIndex {
 pub struct RecipeData {
     pub metadata: MetadataResult,
     pub ingredients: Vec<String>,
+    pub cookware: Vec<String>,
 }
 
 struct Indexes {
@@ -38,13 +39,12 @@ impl Indexes {
         let mut srch = BTreeMap::new();
         let insert_search_entry = |index: &mut BTreeMap<_, _>, entry: RecipeEntry| {
             let content = entry.read().expect("can't read recipe");
-            let metadata = content.metadata(&parser);
-            let ingredients = content.ingredients(&parser);
             index.insert(
                 entry.path().to_owned(),
                 RecipeData {
-                    metadata,
-                    ingredients,
+                    metadata: content.metadata(&parser),
+                    ingredients: content.ingredients(&parser),
+                    cookware: content.cookware(&parser),
                 },
             );
         };
@@ -72,6 +72,7 @@ impl Indexes {
             RecipeData {
                 metadata: content.metadata(&self.parser),
                 ingredients: content.ingredients(&self.parser),
+                cookware: content.cookware(&self.parser),
             },
         );
         Ok(())

--- a/src/cmd/serve/async_index.rs
+++ b/src/cmd/serve/async_index.rs
@@ -7,7 +7,7 @@ use std::{
 
 use anyhow::Result;
 use camino::{Utf8Path, Utf8PathBuf};
-use cooklang::{CooklangParser, MetadataResult};
+use cooklang::{CooklangParser, RecipeResult};
 use cooklang_fs::{FsIndex, RecipeEntry};
 use notify::{RecommendedWatcher, Watcher};
 use serde::Serialize;
@@ -20,7 +20,7 @@ pub struct AsyncFsIndex {
 struct Indexes {
     parser: CooklangParser,
     fs: FsIndex,
-    srch: BTreeMap<Utf8PathBuf, MetadataResult>,
+    srch: BTreeMap<Utf8PathBuf, RecipeResult>,
 }
 
 impl Indexes {
@@ -33,8 +33,8 @@ impl Indexes {
         let mut srch = BTreeMap::new();
         let insert_search_entry = |index: &mut BTreeMap<_, _>, entry: RecipeEntry| {
             let content = entry.read().expect("can't read recipe");
-            let meta = content.metadata(&parser);
-            index.insert(entry.path().to_owned(), meta);
+            let recipe = content.parse(&parser);
+            index.insert(entry.path().to_owned(), recipe);
         };
         for entry in fs.get_all() {
             insert_search_entry(&mut srch, entry);
@@ -54,8 +54,8 @@ impl Indexes {
     }
 
     fn insert_srch(&mut self, path: &Utf8Path) -> Result<(), cooklang_fs::Error> {
-        let meta = RecipeEntry::new(path).read()?.metadata(&self.parser);
-        self.srch.insert(path.to_owned(), meta);
+        let recipe = RecipeEntry::new(path).read()?.parse(&self.parser);
+        self.srch.insert(path.to_owned(), recipe);
         Ok(())
     }
 
@@ -133,8 +133,8 @@ impl AsyncFsIndex {
 
     pub async fn search<T>(
         &self,
-        pred: impl Fn(&RecipeEntry, Option<&MetadataResult>) -> bool,
-        map: impl Fn(RecipeEntry, Option<&MetadataResult>) -> T,
+        pred: impl Fn(&RecipeEntry, Option<&RecipeResult>) -> bool,
+        map: impl Fn(RecipeEntry, Option<&RecipeResult>) -> T,
         skip: usize,
         take: usize,
     ) -> Vec<T> {
@@ -143,9 +143,9 @@ impl AsyncFsIndex {
             .fs
             .get_all()
             .filter_map(|entry| {
-                let meta = indexes.srch.get(entry.path());
-                match pred(&entry, meta) {
-                    true => Some((entry, meta)),
+                let recipe = indexes.srch.get(entry.path());
+                match pred(&entry, recipe) {
+                    true => Some((entry, recipe)),
                     false => None,
                 }
             })

--- a/src/cmd/serve/handlers/index.rs
+++ b/src/cmd/serve/handlers/index.rs
@@ -59,6 +59,7 @@ pub async fn index(
                 let tokens = r.read().ok().map(|c| RecipeData {
                     metadata: c.metadata(&state.parser),
                     ingredients: c.ingredients(&state.parser),
+                    cookware: c.cookware(&state.parser),
                 });
                 recipes.push(recipe_entry_context(r, &state, tokens.as_ref()).unwrap());
             }

--- a/src/cmd/serve/handlers/index.rs
+++ b/src/cmd/serve/handlers/index.rs
@@ -55,8 +55,8 @@ pub async fn index(
                 path => clean_path(dir.path(), &state.base_path)
             }),
             cooklang_fs::Entry::Recipe(r) => {
-                let meta = r.read().ok().map(|c| c.metadata(&state.parser));
-                recipes.push(recipe_entry_context(r, &state, meta.as_ref()).unwrap());
+                let recipe = r.read().ok().map(|c| c.parse(&state.parser));
+                recipes.push(recipe_entry_context(r, &state, recipe.as_ref()).unwrap());
             }
         }
     }

--- a/src/cmd/serve/handlers/index.rs
+++ b/src/cmd/serve/handlers/index.rs
@@ -11,6 +11,7 @@ use serde::Deserialize;
 
 use crate::cmd::serve::{locale::UserLocale, S};
 
+use super::super::async_index::RecipeData;
 use super::{check_path, clean_path, mj_ok, recipe_entry_context};
 
 #[derive(Deserialize)]
@@ -55,8 +56,11 @@ pub async fn index(
                 path => clean_path(dir.path(), &state.base_path)
             }),
             cooklang_fs::Entry::Recipe(r) => {
-                let recipe = r.read().ok().map(|c| c.parse(&state.parser));
-                recipes.push(recipe_entry_context(r, &state, recipe.as_ref()).unwrap());
+                let tokens = r.read().ok().map(|c| RecipeData {
+                    metadata: c.metadata(&state.parser),
+                    ingredients: c.ingredients(&state.parser),
+                });
+                recipes.push(recipe_entry_context(r, &state, tokens.as_ref()).unwrap());
             }
         }
     }

--- a/src/cmd/serve/handlers/mod.rs
+++ b/src/cmd/serve/handlers/mod.rs
@@ -164,6 +164,7 @@ fn tag_context(name: &str, ui_config: &UiConfig) -> Value {
 #[derive(Debug)]
 enum Searcher {
     All(Vec<Self>),
+    Not(Box<Self>),
     NamePart(String),
     Tag(String),
     Ingredient(String),
@@ -174,6 +175,7 @@ impl Searcher {
     fn matches_recipe(&self, name: &str, tokens: &RecipeData) -> bool {
         match self {
             Self::All(v) => v.iter().all(|s| s.matches_recipe(name, tokens)),
+            Self::Not(searcher) => !searcher.matches_recipe(name, tokens),
             Self::NamePart(part) => name.to_lowercase().contains(part),
             Self::Tag(tag) => match tokens.metadata.valid_output() {
                 Some(meta) => meta.tags().unwrap_or(&[]).contains(tag),

--- a/src/cmd/serve/handlers/mod.rs
+++ b/src/cmd/serve/handlers/mod.rs
@@ -167,6 +167,7 @@ enum Searcher {
     NamePart(String),
     Tag(String),
     Ingredient(String),
+    Cookware(String),
 }
 
 impl Searcher {
@@ -182,6 +183,10 @@ impl Searcher {
                 .ingredients
                 .iter()
                 .any(|str| &str.to_lowercase() == ingredient),
+            Self::Cookware(cookware) => tokens
+                .cookware
+                .iter()
+                .any(|str| &str.to_lowercase() == cookware),
         }
     }
 }

--- a/src/cmd/serve/handlers/mod.rs
+++ b/src/cmd/serve/handlers/mod.rs
@@ -164,6 +164,7 @@ fn tag_context(name: &str, ui_config: &UiConfig) -> Value {
 #[derive(Debug)]
 enum Searcher {
     All(Vec<Self>),
+    Any(Vec<Self>),
     Not(Box<Self>),
     NamePart(String),
     Tag(String),
@@ -175,6 +176,7 @@ impl Searcher {
     fn matches_recipe(&self, name: &str, tokens: &RecipeData) -> bool {
         match self {
             Self::All(v) => v.iter().all(|s| s.matches_recipe(name, tokens)),
+            Self::Any(v) => v.iter().any(|s| s.matches_recipe(name, tokens)),
             Self::Not(searcher) => !searcher.matches_recipe(name, tokens),
             Self::NamePart(part) => name.to_lowercase().contains(part),
             Self::Tag(tag) => match tokens.metadata.valid_output() {

--- a/src/cmd/serve/handlers/mod.rs
+++ b/src/cmd/serve/handlers/mod.rs
@@ -100,7 +100,7 @@ fn recipe_entry_context(
     let mut error = false;
     let mut image = None;
 
-    if let Some(m) = recipe.and_then(|res| res.metadata.valid_output()) {
+    if let Some(m) = recipe.and_then(|r| r.metadata.as_ref()) {
         let tags = Value::from_iter(
             m.tags()
                 .unwrap_or(&[])
@@ -179,7 +179,7 @@ impl Searcher {
             Self::Any(v) => v.is_empty() | v.iter().any(|s| s.matches_recipe(name, tokens)),
             Self::Not(searcher) => !searcher.matches_recipe(name, tokens),
             Self::NamePart(part) => name.to_lowercase().contains(part),
-            Self::Tag(tag) => match tokens.metadata.valid_output() {
+            Self::Tag(tag) => match tokens.metadata.as_ref() {
                 Some(meta) => meta.tags().unwrap_or(&[]).iter().any(|t| t.contains(tag)),
                 None => false,
             },

--- a/src/cmd/serve/handlers/mod.rs
+++ b/src/cmd/serve/handlers/mod.rs
@@ -1,10 +1,10 @@
 use camino::{Utf8Path, Utf8PathBuf};
-use cooklang::RecipeResult;
 use cooklang_fs::RecipeEntry;
 use minijinja::{context, Value};
 
 use crate::{config::UiConfig, util::meta_name};
 
+use super::async_index::RecipeData;
 use super::AppState;
 
 pub mod about;
@@ -94,14 +94,13 @@ fn clean_path(p: &Utf8Path, base_path: &Utf8Path) -> Utf8PathBuf {
 fn recipe_entry_context(
     r: RecipeEntry,
     state: &AppState,
-    recipe: Option<&RecipeResult>,
+    recipe: Option<&RecipeData>,
 ) -> Option<Value> {
     let mut metadata = Value::UNDEFINED;
     let mut error = false;
     let mut image = None;
 
-    if let Some(re) = recipe.and_then(|res| res.valid_output()) {
-        let m = &re.metadata;
+    if let Some(m) = recipe.and_then(|res| res.metadata.valid_output()) {
         let tags = Value::from_iter(
             m.tags()
                 .unwrap_or(&[])
@@ -163,26 +162,26 @@ fn tag_context(name: &str, ui_config: &UiConfig) -> Value {
 }
 
 #[derive(Debug)]
-struct Searcher {
-    tags: Vec<String>,
-    name_parts: Vec<String>,
+enum Searcher {
+    All(Vec<Self>),
+    NamePart(String),
+    Tag(String),
+    Ingredient(String),
 }
 
 impl Searcher {
-    fn matches_recipe(&self, name: &str, tags: &[String]) -> bool {
-        let name = name.to_lowercase();
-        for part in &self.name_parts {
-            if !name.contains(part) {
-                return false;
-            }
+    fn matches_recipe(&self, name: &str, tokens: &RecipeData) -> bool {
+        match self {
+            Self::All(v) => v.iter().all(|s| s.matches_recipe(name, tokens)),
+            Self::NamePart(part) => name.to_lowercase().contains(part),
+            Self::Tag(tag) => match tokens.metadata.valid_output() {
+                Some(meta) => meta.tags().unwrap_or(&[]).contains(tag),
+                None => false,
+            },
+            Self::Ingredient(ingredient) => tokens
+                .ingredients
+                .iter()
+                .any(|str| &str.to_lowercase() == ingredient),
         }
-
-        for tag in &self.tags {
-            if !tags.contains(tag) {
-                return false;
-            }
-        }
-
-        true
     }
 }

--- a/src/cmd/serve/handlers/mod.rs
+++ b/src/cmd/serve/handlers/mod.rs
@@ -1,5 +1,5 @@
 use camino::{Utf8Path, Utf8PathBuf};
-use cooklang::MetadataResult;
+use cooklang::RecipeResult;
 use cooklang_fs::RecipeEntry;
 use minijinja::{context, Value};
 
@@ -94,13 +94,14 @@ fn clean_path(p: &Utf8Path, base_path: &Utf8Path) -> Utf8PathBuf {
 fn recipe_entry_context(
     r: RecipeEntry,
     state: &AppState,
-    meta: Option<&MetadataResult>,
+    recipe: Option<&RecipeResult>,
 ) -> Option<Value> {
     let mut metadata = Value::UNDEFINED;
     let mut error = false;
     let mut image = None;
 
-    if let Some(m) = meta.and_then(|res| res.valid_output()) {
+    if let Some(re) = recipe.and_then(|res| res.valid_output()) {
+        let m = &re.metadata;
         let tags = Value::from_iter(
             m.tags()
                 .unwrap_or(&[])

--- a/src/cmd/serve/handlers/mod.rs
+++ b/src/cmd/serve/handlers/mod.rs
@@ -178,17 +178,17 @@ impl Searcher {
             Self::Not(searcher) => !searcher.matches_recipe(name, tokens),
             Self::NamePart(part) => name.to_lowercase().contains(part),
             Self::Tag(tag) => match tokens.metadata.valid_output() {
-                Some(meta) => meta.tags().unwrap_or(&[]).contains(tag),
+                Some(meta) => meta.tags().unwrap_or(&[]).iter().any(|t| t.contains(tag)),
                 None => false,
             },
             Self::Ingredient(ingredient) => tokens
                 .ingredients
                 .iter()
-                .any(|str| &str.to_lowercase() == ingredient),
+                .any(|str| str.to_lowercase().contains(ingredient)),
             Self::Cookware(cookware) => tokens
                 .cookware
                 .iter()
-                .any(|str| &str.to_lowercase() == cookware),
+                .any(|str| str.to_lowercase().contains(cookware)),
         }
     }
 }

--- a/src/cmd/serve/handlers/mod.rs
+++ b/src/cmd/serve/handlers/mod.rs
@@ -175,8 +175,8 @@ enum Searcher {
 impl Searcher {
     fn matches_recipe(&self, name: &str, tokens: &RecipeData) -> bool {
         match self {
-            Self::All(v) => v.iter().all(|s| s.matches_recipe(name, tokens)),
-            Self::Any(v) => v.iter().any(|s| s.matches_recipe(name, tokens)),
+            Self::All(v) => v.is_empty() | v.iter().all(|s| s.matches_recipe(name, tokens)),
+            Self::Any(v) => v.is_empty() | v.iter().any(|s| s.matches_recipe(name, tokens)),
             Self::Not(searcher) => !searcher.matches_recipe(name, tokens),
             Self::NamePart(part) => name.to_lowercase().contains(part),
             Self::Tag(tag) => match tokens.metadata.valid_output() {

--- a/src/cmd/serve/handlers/search.rs
+++ b/src/cmd/serve/handlers/search.rs
@@ -42,7 +42,6 @@ pub async fn search(
     Query(query): Query<SearchQuery>,
 ) -> Response {
     let srch = Searcher::from(query);
-    tracing::trace!("{:?}", srch);
 
     let recipes = state
         .recipe_index

--- a/src/cmd/serve/handlers/search.rs
+++ b/src/cmd/serve/handlers/search.rs
@@ -97,6 +97,8 @@ impl From<SearchQuery> for Searcher {
                     }
                 } else if let Some(ingredient) = part.strip_prefix("uses:") {
                     parts.push(Searcher::Ingredient(ingredient.to_owned()));
+                } else if let Some(cookware) = part.strip_prefix("needs:") {
+                    parts.push(Searcher::Cookware(cookware.to_owned()));
                 } else {
                     parts.push(Searcher::NamePart(part.to_owned()));
                 }
@@ -117,6 +119,7 @@ impl Searcher {
             Searcher::NamePart(name) => name.to_owned(),
             Searcher::Tag(tag) => format!("tag:{tag}"),
             Searcher::Ingredient(ingredient) => format!("uses:{ingredient}"),
+            Searcher::Cookware(cookware) => format!("needs:{cookware}"),
         }
     }
 
@@ -126,6 +129,7 @@ impl Searcher {
             Searcher::NamePart(name) => name.is_empty(),
             Searcher::Tag(tag) => tag.is_empty(),
             Searcher::Ingredient(ingredient) => ingredient.is_empty(),
+            Searcher::Cookware(cookware) => cookware.is_empty(),
         }
     }
 }

--- a/src/cmd/serve/handlers/search.rs
+++ b/src/cmd/serve/handlers/search.rs
@@ -1,3 +1,5 @@
+use std::borrow::Borrow;
+
 use axum::{
     extract::{Query, State},
     http::HeaderMap,
@@ -265,7 +267,11 @@ impl Searcher {
                 .join(" | "),
             Searcher::Not(s) => {
                 let str = s.to_query();
-                format!("!{str}")
+                match s.borrow() {
+                    Searcher::Any(_) => format!("!({str})"),
+                    Searcher::All(_) => format!("!({str})"),
+                    _ => format!("!{str}"),
+                }
             }
             Searcher::NamePart(name) => name.replace(" ", "+"),
             Searcher::Tag(tag) => format!("tag:{tag}").replace(" ", "+"),

--- a/src/cmd/serve/handlers/search.rs
+++ b/src/cmd/serve/handlers/search.rs
@@ -109,9 +109,9 @@ impl From<SearchQuery> for Searcher {
                     } else {
                         None
                     }
-                } else if let Some(ingredient) = part.strip_prefix("uses:") {
+                } else if let Some(ingredient) = part.strip_prefix("ingredient:") {
                     Some(Searcher::Ingredient(ingredient.to_owned()))
-                } else if let Some(cookware) = part.strip_prefix("needs:") {
+                } else if let Some(cookware) = part.strip_prefix("cookware:") {
                     Some(Searcher::Cookware(cookware.to_owned()))
                 } else {
                     Some(Searcher::NamePart(part.to_owned()))

--- a/src/cmd/serve/handlers/search.rs
+++ b/src/cmd/serve/handlers/search.rs
@@ -47,8 +47,9 @@ pub async fn search(
         state
             .recipe_index
             .search(
-                |entry, meta| match meta.and_then(|r| r.valid_output()) {
-                    Some(m) => {
+                |entry, recipe| match recipe.and_then(|r| r.valid_output()) {
+                    Some(r) => {
+                        let m = &r.metadata;
                         let name = meta_name(m).unwrap_or(entry.name());
                         srch.matches_recipe(name, m.tags().unwrap_or(&[]))
                     }

--- a/src/cmd/serve/handlers/search.rs
+++ b/src/cmd/serve/handlers/search.rs
@@ -48,7 +48,7 @@ pub async fn search(
         .search(
             |entry, tokens| match tokens {
                 Some(t) => {
-                    let name = if let Some(meta) = t.metadata.valid_output() {
+                    let name = if let Some(meta) = t.metadata.as_ref() {
                         meta_name(meta).unwrap_or(entry.name())
                     } else {
                         entry.name()

--- a/src/cmd/serve/handlers/search.rs
+++ b/src/cmd/serve/handlers/search.rs
@@ -101,7 +101,8 @@ impl From<SearchQuery> for Searcher {
                         }
                         None => part,
                     }
-                };
+                }
+                .replace("+", " ");
                 let next = if let Some(tag) = part.strip_prefix("tag:") {
                     if is_valid_tag(tag) {
                         Some(Searcher::Tag(tag.to_owned()))
@@ -140,10 +141,10 @@ impl Searcher {
                 let str = s.to_query();
                 format!("!{str}")
             }
-            Searcher::NamePart(name) => name.to_owned(),
-            Searcher::Tag(tag) => format!("tag:{tag}"),
-            Searcher::Ingredient(ingredient) => format!("uses:{ingredient}"),
-            Searcher::Cookware(cookware) => format!("needs:{cookware}"),
+            Searcher::NamePart(name) => name.replace(" ", "+"),
+            Searcher::Tag(tag) => format!("tag:{tag}").replace(" ", "+"),
+            Searcher::Ingredient(ingredient) => format!("uses:{ingredient}").replace(" ", "+"),
+            Searcher::Cookware(cookware) => format!("needs:{cookware}").replace(" ", "+"),
         }
     }
 


### PR DESCRIPTION
Expands the search functionality to additionally support:
- searching by ingredient (`ingredient:<keyword>`)
- searching by cookware (`cookware:<keyword>`)
- excluding a search term (`!<term>`, for example, `!cookware:oven` for recipes that don't need an oven)
- searching for ingredients and cookware that contain spaces (`<a>+<b>`, for example, `ingredient:black+beans`)
  - While this does allow tags to include spaces, it is not presently used due to being considered invalid.
- searching partial matches for tags, ingredients, and cookware (for example, `tag:din` would match the `dinner` tag)
- locally group search terms (`(<term> <term>)`, for example, `!(ingredient:chicken ingredient:pasta)` would exclude recipes that contain both chicken and pasta)
- searching for either of a series of terms (`<term> | <term>`, for example, `ingredient:chicken | ingredient:steak | ingredient:beef` would match any recipes with one of those three ingredients)