### PR TITLE
fix: Verify modified files weren't just created

### DIFF
--- a/src/cmd/serve/async_index.rs
+++ b/src/cmd/serve/async_index.rs
@@ -128,8 +128,14 @@ impl AsyncFsIndex {
             while let Some(update) = in_updt_rx.recv().await {
                 match &update {
                     Update::Modified { path } => {
-                        tracing::info!("Updated '{path}'");
-                        let _ = indexes.write().await.revalidate(path);
+                        let mut indexes = indexes.write().await;
+                        if indexes.fs.contains(path.as_str()) {
+                            tracing::info!("Updated '{path}'");
+                            let _ = indexes.revalidate(path);
+                        } else {
+                            tracing::info!("Added '{path}'");
+                            let _ = indexes.insert(path);
+                        }
                     }
                     Update::Added { path } => {
                         tracing::info!("Added '{path}'");


### PR DESCRIPTION
Due to <https://docs.rs/notify/7.0.0/notify/#editor-behaviour>, we cannot guarantee that a "Modified" event isn't an "Added" event. Since our `FsIndex` already tracks the files we know about, we'll check if it is aware of the file that was "modified", inserting it if not.