### PR TITLE
Fix typo in German localization ("Deutsche" -> "Deutsch")

### DIFF
--- a/ui/i18n/de.json
+++ b/ui/i18n/de.json
@@ -1,5 +1,5 @@
 {
-    "_lang": "Deutsche",
+    "_lang": "Deutsch",
     "index": {
         "search": "Suche",
         "noRecipes": "Keine Rezepte gefunden"


### PR DESCRIPTION
What it says on the tin, there was a small typo in the language key for German.