### PR TITLE
Specify which extension name was not recognized while parsing config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -351,7 +351,7 @@ mod extensions_serde {
                 // https://github.com/serde-rs/serde/issues/2467
                 while let Some((name, enabled)) = map.next_entry::<String, bool>()? {
                     let e = Extensions::from_name(&name.replace(' ', "_").to_uppercase())
-                        .ok_or_else(|| A::Error::custom("Unknown extension name"))?;
+                        .ok_or_else(|| A::Error::custom(format!("Unknown extension name: {}", name)))?;
                     if enabled {
                         extensions |= e;
                     }


### PR DESCRIPTION
While parsing the extensions table, specify which extension was unrecognized to avoid cryptic errors.